### PR TITLE
How to set the version of a package

### DIFF
--- a/docs/core/tools/dotnet-pack.md
+++ b/docs/core/tools/dotnet-pack.md
@@ -80,6 +80,10 @@ Sets the serviceable flag in the package. For more information, see https://aka.
 
 Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`.
 
+`/p:Version=<version>`
+
+Sets the version of the package 
+
 ## Examples
 
 Pack the project in the current directory:


### PR DESCRIPTION
It is not obvious how to set the version number of a package without editing the `csproj` file. This documents the MSBuild parameter to do so.
